### PR TITLE
security: harden GitHub Actions workflows (Shai Hulud campaign)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @SAP/feature-toogle-node-team
+.github/workflows/ @SAP/feature-toogle-node-team

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ jobs:
   build:
     name: Full Build (node ${{ matrix.node_version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node_version: [20.x, 22.x, 24.x]
-      # https://stackoverflow.com/questions/61070925/github-actions-disable-auto-cancel-when-job-fails
       fail-fast: false
 
     steps:
@@ -24,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run ci

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   release:
@@ -18,10 +19,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run ci
 
       - name: Publish to NPM
-        run: npm publish
+        run: npm publish --provenance


### PR DESCRIPTION
## Summary

Remediation for the SAP OSPO Shai Hulud campaign hardening requirements (Control 5 + workflow hardening).

### Changes

- **ci.yml** — add `permissions: contents: read`, change `npm install` → `npm ci`
- **commitlint.yml** — add `permissions: contents: read` and `pull-requests: read`
- **release.yml** — add `contents: read` to permissions block, change `npm install` → `npm ci`, add `--provenance` to `npm publish`
- **.github/CODEOWNERS** — add file to enforce review ownership on workflows

### Why

Without explicit `permissions:` blocks, GitHub Actions defaults to write access on all scopes — a supply chain attack vector. Restricting to least-privilege read-only permissions limits blast radius if a workflow is compromised.

### Remaining items (require admin access)
- Strengthen branch protection rules on `master` (require 1 PR review, dismiss stale, block force push)