### PR TITLE
ci: harden GitHub Actions workflow permissions (Shai Hulud campaign)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ jobs:
   build:
     name: Full Build (node ${{ matrix.node_version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node_version: [20.x, 22.x, 24.x]
-      # https://stackoverflow.com/questions/61070925/github-actions-disable-auto-cancel-when-job-fails
       fail-fast: false
 
     steps:
@@ -24,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run ci

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   commitlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,12 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -18,10 +20,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run ci
 
       - name: Publish to NPM
-        run: npm publish
+        run: npm publish --provenance


### PR DESCRIPTION
## Summary

Remediation for SAP OSPO Shai Hulud campaign hardening requirements.

### Changes

- **ci.yml** — add `permissions: contents: read`, change `npm install` → `npm ci`
- **commitlint.yml** — add `permissions: contents: read` and `pull-requests: read`
- **release.yml** — add `contents: read` to permissions block, add `environment: npm-publish`, change `npm install` → `npm ci`, add `--provenance` to `npm publish`

### Why

Without explicit `permissions:` blocks, GitHub Actions defaults to write access on all scopes — a supply chain attack vector. Restricting to least-privilege read-only permissions limits blast radius if a workflow is compromised.

### Completed ✅
- **Branch protection on `master`** — 1 required PR review, dismiss stale reviews, block force push, required status checks (CI + commitlint)